### PR TITLE
Refactor install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,100 +6,95 @@
 # GNU:        General Public License v3.0
 ################################################################################
 
-# Upgrade
+## Upgrade
 #apt-get update -y
-
-# apt-get upgrade -y # causes problems when you forced on an interactive screen
+#
+#apt-get upgrade -y # causes problems when forced on an interactive screen
 #apt-get install software-properties-common git zip unzip dialog -y
 
 tee <<-EOF
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🌎  NOTICE: PGBlitz Version 9 - Installer
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-By installing, you agreeing to the terms and conditions of the GNUv3 License!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+By installing, you agree to the terms and conditions of the GNUv3 License!
 
 Thanks To: Davaz, Deiteq, FlickerRate, ClownFused, MrDoob, Sub7Seven,
 TimeKills, The Creator, and to the caring Community (& Linux Noobs)!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Please Standby!
 EOF
-#sleep 4
 
-# Delete If it Exist for Cloning
-if [ -e "/pg/blitz" ]; then rm -rf /pg/blitz; fi
-if [ -e "/pg/stage" ]; then rm -rf /pg/stage; fi
-rm -rf /pg/stage/place.holder 1>/dev/null 2>&1
+# Remove PGBlitz if it exists
+[[ -e /pg/pgblitz ]] && rm -rf /pg/pgblitz
+[[ -e /pg/stage ]] && rm -rf /pg/stage
 
-# Make Critical Folders
-mkdir -p /pg /pg/logs /pg/var /pg/data /pg/stage /pg/logs /pg/tmp
-chmod 775 /pg /pg/logs /pg/var /pg/data /pg/stage /pg/logs /pg/tmp
-chown 1000:1000 /pg /pg/logs /pg/var /pg/data /pg/stage /pg/logs /pg/tmp
+# Create base directories
+mkdir -p /pg/{data,logs,stage,tmp,var}
+chmod 775 /pg/{data,logs,stage,tmp,var}
+chown 1000:1000 /pg/{data,logs,stage,tmp,var}
 
-# Clone the Program to Stage for Installation
+# Clone into /pg/stage
 git clone -b v1 --single-branch https://github.com/PGBlitz/Stage.git /pg/stage
 
-# Checking to See if the Installer ever Installed Python; if so... skip
+# Check if Python is installed
 var37="/pg/var/python.firstime"
-if [ ! -e "${var37}" ]; then
+if [[ ! -e ${var37} ]]; then
   bash /pg/stage/pyansible.sh
   touch /pg/var/python.firstime
 fi
 
-# Clone PGBlitz into /pg/blitz/ ~ this is found under the module - Stage
-# The values of clone should automatically change with a version change above
+# Clone PGBlitz into /pg/pgblitz/
 ansible-playbook /pg/stage/clone.yml
 
-# Copy Starting Commands for PGBlitz
+# Copy startup scripts
 path="/pg/stage/alias"
-cp -t /bin $path/plexguide $path/pg $path/pgblitz
+cp $path/{pg,pgblitz,plexguide} /bin
 
-# Verifying the Commands Installed
+# Verify startup scripts are installed
 tee <<-EOF
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-⌛  Verifiying Started Commands Installed via @ /bin
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⌛  Verifying startup scripts installed in /bin...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
 
-# Installation fails if the pgblitz command is not in the correct location
-if [[ ! -e "/bin/pgblitz" ]]; then
+# Fails if startup scripts are not in the correct location
+if [[ ! -e /bin/pg ]] || [[ ! -e /bin/pgblitz ]] || [[ ! -e /bin/plexguide ]]; then
 tee <<-EOF
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-⛔️  WARNING! The PGBlitz Installer Failed ~ http://pgblitz.wiki
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Please Reinstall PGBlitz by running the Command Again! This step is to
-ensure that everything is working prior to the install!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⛔️  WARNING! PGBlitz install failed! ~ http://pgblitz.wiki
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Reinstall PGBlitz by running the installer again.
 
-Ensure that you utilizing the correct versions of linux as described on
-the installation page!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Make sure you are using the correct version of linux as mentioned in the
+install instructions!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EXITING!!!
 
 EOF
 exit
 fi
 
-# If nothing failed, notify the user that installation passed!
+# Success
 tee <<-EOF
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅️  PASSED! The PGBlitz Command Installed! ~ http://pgblitz.wiki
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅️  PASSED! PGBlitz install successful! ~ http://pgblitz.wiki
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
 
-# creates a blank var; if this executes; pgblitz will go through the install process
+# Creates a blank variable; if successful, pgblitz will run through the install process
 touch /pg/var/new.install
 
-chmod 775 /bin/plexguide /bin/pgblitz /bin/pg
-chown 1000:1000 /bin/plexguide /bin/pgblitz /bin/pg
+chmod 775 /bin/{pg,pgblitz,plexguide}
+chown 1000:1000 /bin/{pg,pgblitz,plexguide}
 
 tee <<-EOF
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-↘️  Start AnyTime By Typing >>> pgblitz [or] plexguide [or] pg
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+↘️  Start by typing >>> pg [or] pgblitz [or] plexguide
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 EOF


### PR DESCRIPTION
Just provisioned a new instance of v9 and noticed a few issues with the install script. I ended up refactoring the thing.

Install instructions can be simplified to:
`sudo apt install curl -y && curl -s https://raw.githubusercontent.com/PGBlitz/Install/v1/install.sh | sudo -H bash`

Pipe to bash so we can use brace expansion and double brackets (`[[ ]]`). Also, the script runs `sudo rm -rf /pg/pgblitz && sudo rm -rf /pg/stage` itself.